### PR TITLE
Router subscription does not receive tagger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,7 @@
 const tag = require('tagmeme')
 const {mapEffect, batchEffects} = require('raj-compose')
 
-const Result = (function () {
-  const Err = tag('Err')
-  const Ok = tag('Ok')
-  const Result = tag.union([Err, Ok])
-  Result.Err = Err
-  Result.Ok = Ok
-  return Result
-})()
+const Result = tag.namedUnion(['Ok', 'Err'])
 
 function loadProgram (program, programMsg) {
   return function (dispatch) {
@@ -32,14 +25,16 @@ function spa ({
   errorProgram,
   containerView
 }) {
-  const GetRoute = tag('GetRoute')
-  const GetProgram = tag('GetProgram')
-  const ProgramMsg = tag('ProgramMsg')
-  const Msg = tag.union([
+  const Msg = tag.namedUnion([
+    'GetRoute',
+    'GetProgram',
+    'ProgramMsg'
+  ])
+  const {
     GetRoute,
     GetProgram,
     ProgramMsg
-  ])
+  } = Msg
 
   const init = (() => {
     const [
@@ -49,7 +44,7 @@ function spa ({
     const {
       effect: routerEffect,
       cancel: routerCancel
-    } = router.subscribe(GetRoute)
+    } = router.subscribe()
     const model = {
       routerCancel,
       isTransitioning: false,
@@ -57,13 +52,13 @@ function spa ({
       programModel: initialProgramModel
     }
     const effect = batchEffects([
-      routerEffect,
+      mapEffect(routerEffect, GetRoute),
       mapEffect(initialProgramEffect, ProgramMsg)
     ])
     return [model, effect]
   })()
 
-  function transitionToProgram (model, program, props) {
+  function transitionToProgram (model, program) {
     const [
       newProgramModel,
       newProgramEffect

--- a/test/index.js
+++ b/test/index.js
@@ -30,26 +30,27 @@ test('spa should return a new program', t => {
 })
 
 test('spa should subscribe to the router', t => {
-  const router = {
-    subscribe (routeMsg) {
-      t.is(typeof routeMsg, 'function')
-
-      return {
-        cancel () {},
-        effect: dispatch => {
-          t.is(typeof dispatch, 'function')
+  return new Promise(resolve => {
+    const router = {
+      subscribe () {
+        return {
+          cancel () {},
+          effect: dispatch => {
+            t.is(typeof dispatch, 'function')
+            resolve()
+          }
         }
       }
     }
-  }
 
-  program(spa({
-    router,
-    initialProgram: noopProgram,
-    getRouteProgram () {
-      return noopProgram
-    }
-  }))
+    program(spa({
+      router,
+      initialProgram: noopProgram,
+      getRouteProgram () {
+        return noopProgram
+      }
+    }))
+  })
 })
 
 test('spa should unsubscribe from the router when the runtime is killed', t => {


### PR DESCRIPTION
This removes the argument to `router.subscription`, instead `mapEffect` is used internally. This aligns with how subscriptions have evolved in recent months. `raj-spa` was problematic and in most cases the tagger was unnecessary `x => x` boiler code.