### PR TITLE
Add keyed program support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ interface ViewContainerModel {
 }
 ```
 
+### Self-managed programs and nested SPAs
+By default, every URL change will trigger a `getRouteProgram()`.
+This means the current program will be torn down and the next program set up.
+For a minor change like in query params, this can be expensive, lose useful state, and thrash the view.
+Programs that can resolve these route changes can be thought of as *self-managed programs*.
+If the program is the same between `getRouteProgram` calls, we pass down the route change to the program to handle.
+
+```js
+function getRouteProgram (route, { selfManaged }) {
+  if (route === '/simple-page') {
+    return simpleProgram
+  }
+  if (route.startsWith('/nested-spa')) {
+    return selfManaged(
+      'my-nested-spa',
+      routeSubscription => nestedSpa(routeSubscription)
+    )
+  }
+}
+```
+
+The `selfManaged` function takes an arbitrary value which is used for program equality and the function which will be called to set up the program.
+That function receives a subscription which it can watch for route changes.
+
 ### Questions
 
 #### Does this work with React Native?

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By default, every URL change will trigger a `getRouteProgram()`.
 This means the current program will be torn down and the next program set up.
 For a minor change like in query params, this can be expensive, lose useful state, and thrash the view.
 Programs that can resolve these route changes can be thought of as *self-managed programs*.
-If the program is the same between `getRouteProgram` calls, we pass down the route change to the program to handle.
+If the program is the same between `getRouteProgram` calls, we pass down a `RajRouter` to the program. The program can subscribe to routes emitted from this router.
 
 ```js
 function getRouteProgram (route, { selfManaged }) {
@@ -125,7 +125,7 @@ function getRouteProgram (route, { selfManaged }) {
   if (route.startsWith('/nested-spa')) {
     return selfManaged(
       'my-nested-spa',
-      routeSubscription => nestedSpa(routeSubscription)
+      router => nestedSpa(router)
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ const {mapEffect, batchEffects} = require('raj-compose')
 const {
   Result,
   isPromise,
-  selfManaged,
-  isSelfManaged,
+  keyed,
+  isKeyed,
   createEmitter
 } = require('./utils')
 
@@ -81,8 +81,8 @@ function spa ({
       GetRoute: route => {
         let programKey = null
         let routeEmitter = null
-        let newProgram = getRouteProgram(route, { selfManaged })
-        if (isSelfManaged(newProgram)) {
+        let newProgram = getRouteProgram(route, { keyed })
+        if (isKeyed(newProgram)) {
           const { key, makeProgram } = newProgram
           const isContinuation = model.programKey && model.programKey === key
           if (isContinuation) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,11 +6,11 @@ function isPromise (value) {
   return value && (value.then && value.catch)
 }
 
-function selfManaged (key, makeProgram) {
+function keyed (key, makeProgram) {
   return { _isSelfManaged: true, key, makeProgram }
 }
 
-function isSelfManaged (program) {
+function isKeyed (program) {
   return program && program._isSelfManaged
 }
 
@@ -41,6 +41,6 @@ function createEmitter ({ listeners = [], initialValue }) {
 
 exports.Result = Result
 exports.isPromise = isPromise
-exports.selfManaged = selfManaged
-exports.isSelfManaged = isSelfManaged
+exports.keyed = keyed
+exports.isKeyed = isKeyed
 exports.createEmitter = createEmitter

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,10 @@ const { union } = require('tagmeme')
 
 const Result = union(['Ok', 'Err'])
 
+function isPromise (value) {
+  return value && (value.then && value.catch)
+}
+
 function selfManaged (key, makeProgram) {
   return { _isSelfManaged: true, key, makeProgram }
 }
@@ -10,9 +14,11 @@ function isSelfManaged (program) {
   return program && program._isSelfManaged
 }
 
-function createEmitter (listeners = []) {
+function createEmitter ({ listeners = [], initialValue }) {
+  let lastValue = initialValue
   return {
     emit (value) {
+      lastValue = value
       listeners.forEach(l => l(value))
     },
     subscribe () {
@@ -22,6 +28,7 @@ function createEmitter (listeners = []) {
           if (!listener) {
             listener = dispatch
             listeners.push(listener)
+            listener(lastValue)
           }
         },
         cancel () {
@@ -33,6 +40,7 @@ function createEmitter (listeners = []) {
 }
 
 exports.Result = Result
+exports.isPromise = isPromise
 exports.selfManaged = selfManaged
 exports.isSelfManaged = isSelfManaged
 exports.createEmitter = createEmitter

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,38 @@
+const { union } = require('tagmeme')
+
+const Result = union(['Ok', 'Err'])
+
+function selfManaged (key, makeProgram) {
+  return { _isSelfManaged: true, key, makeProgram }
+}
+
+function isSelfManaged (program) {
+  return program && program._isSelfManaged
+}
+
+function createEmitter (listeners = []) {
+  return {
+    emit (value) {
+      listeners.forEach(l => l(value))
+    },
+    subscribe () {
+      let listener
+      return {
+        effect (dispatch) {
+          if (!listener) {
+            listener = dispatch
+            listeners.push(listener)
+          }
+        },
+        cancel () {
+          listeners = listeners.filter(l => l !== listener)
+        }
+      }
+    }
+  }
+}
+
+exports.Result = Result
+exports.selfManaged = selfManaged
+exports.isSelfManaged = isSelfManaged
+exports.createEmitter = createEmitter

--- a/test/index.js
+++ b/test/index.js
@@ -96,7 +96,7 @@ const tick = fn => setTimeout(fn, 0)
 
 test('spa should reuse self-managed programs', async t => {
   /*
-    The selfManaged(key, makeProgram) makeProgram function
+    The keyed(key, makeProgram) makeProgram function
       should only be called once and is then reused for
       any route that gets emitted.
   */
@@ -111,12 +111,12 @@ test('spa should reuse self-managed programs', async t => {
     kill = program(spa({
       router,
       initialProgram,
-      getRouteProgram (route, { selfManaged }) {
+      getRouteProgram (route, { keyed }) {
         if (route === '/baz') {
           resolve()
         }
 
-        return selfManaged('child-key', router => {
+        return keyed('child-key', router => {
           t.is(typeof router.subscribe, 'function', 'router.subscribe should be a function')
           return childProgram
         })
@@ -160,8 +160,8 @@ test('spa should emit routes for self-managed programs', async t => {
   const kill = program(spa({
     router,
     initialProgram,
-    getRouteProgram (route, { selfManaged }) {
-      return selfManaged('child-key', getChildProgram)
+    getRouteProgram (route, { keyed }) {
+      return keyed('child-key', getChildProgram)
     }
   }))
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,7 @@
-import { createEmitter } from '../src/utils'
-
 const test = require('ava')
 const spa = require('../src')
-const {program} = require('raj/runtime')
+const { program } = require('raj/runtime')
+const { createEmitter } = require('../src/utils')
 
 const noopProgram = {
   init: [],

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,17 @@
+import { createEmitter } from '../src/utils'
+import test from 'ava'
+
+test('createEmitter should add listeners', t => {
+  const emitter = createEmitter()
+  emitter.subscribe().effect(() => t.pass())
+  emitter.emit()
+})
+
+test('createEmitter should remove listeners', t => {
+  t.plan(0)
+  const emitter = createEmitter()
+  const sub = emitter.subscribe()
+  sub.effect(() => t.fail())
+  sub.cancel()
+  emitter.emit()
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,17 +1,31 @@
 import { createEmitter } from '../src/utils'
 import test from 'ava'
 
-test('createEmitter should add listeners', t => {
-  const emitter = createEmitter()
+test('createEmitter should prime added listeners', t => {
+  const emitter = createEmitter({})
   emitter.subscribe().effect(() => t.pass())
-  emitter.emit()
+})
+
+const skipPrime = isPrimed => fn => x => {
+  if (!isPrimed) {
+    isPrimed = true
+    return
+  }
+  fn(x)
+}
+
+test('createEmitter should add listeners', t => {
+  const emitter = createEmitter({})
+  const skip = skipPrime()
+  emitter.subscribe().effect(skip(x => t.is(x, 4)))
+  emitter.emit(4)
 })
 
 test('createEmitter should remove listeners', t => {
-  t.plan(0)
-  const emitter = createEmitter()
+  t.plan(1)
+  const emitter = createEmitter({})
   const sub = emitter.subscribe()
-  sub.effect(() => t.fail())
+  sub.effect(() => t.pass())
   sub.cancel()
   emitter.emit()
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
-import { createEmitter } from '../src/utils'
-import test from 'ava'
+const test = require('ava')
+const { createEmitter } = require('../src/utils')
 
 test('createEmitter should prime added listeners', t => {
   const emitter = createEmitter({})


### PR DESCRIPTION
My personal use case for this is sidebars. I represent a sidebar in my UI as a program with its own effects and subscriptions. The sidebar does need access to the current route for styling and what-not. When the main program changes I don't want to re-build the sidebar.

There are many other use cases such as:
- Handling fast query param changes
- Having apps inside apps with their own SPAs
- Handling complex animation for a subset of page transitions

I think this solution is pretty cool as an a-la-carte solution. It doesn't break existing routing and is pretty declarative. It's also open-ended; dependency injection still works and if there's no need for the router we don't need to pass it down at all. The coolest thing is that since the router is a `RajRouter` it can be fed back into a child `spa()`.