### PR TITLE
Add getErrorProgram, deprecate errorProgram

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `raj-spa` package exports a single function which takes the following argume
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| `errorProgram` | `Error => RajProgram` | The program used when loading a program rejects with an error. `errorProgram` receives the error and returns a `RajProgram`.
+| `getErrorProgram` | `Error => RajProgram` | The program used when loading a program rejects with an error. `getErrorProgram` receives the error and returns a `RajProgram`.
 | `containerView` | function | A container view which wraps the entire application. The function will receive a `ContainerViewModel` and the sub program's `view` result to encapsulate.
 
 #### Types

--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,16 @@ function loadProgram (programPromise) {
 function spa ({
   // required
   router,
-  getRouteProgram,
   initialProgram,
+  getRouteProgram,
 
   // optional
-  errorProgram,
+  getErrorProgram,
+  errorProgram, // Deprecated
   containerView
 }) {
   const Msg = union(['GetRoute', 'GetProgram', 'ProgramMsg'])
+  getErrorProgram = getErrorProgram || errorProgram
 
   const init = (() => {
     const [initialProgramModel, initialProgramEffect] = initialProgram.init
@@ -97,8 +99,8 @@ function spa ({
         return Result.match(result, {
           Ok: program => transitionToProgram(newModel, program),
           Err: error => {
-            if (errorProgram) {
-              const program = errorProgram(error)
+            if (getErrorProgram) {
+              const program = getErrorProgram(error)
               return transitionToProgram(newModel, program)
             }
             console.error(error)

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,7 @@ test('spa should emit routes for self-managed programs', async t => {
   t.deepEqual(history, ['/foo', '/bar', '/baz'])
 })
 
-test('spa should use errorProgram if loading fails', t => {
+test('spa should use getErrorProgram if loading fails', t => {
   const router = createTestRouter({ initialValue: '/foo' })
   const initialProgram = createTestProgram('initial')
   const failError = new Error('Load fail')
@@ -202,7 +202,7 @@ test('spa should use errorProgram if loading fails', t => {
       getRouteProgram () {
         return Promise.reject(failError)
       },
-      errorProgram (error) {
+      getErrorProgram (error) {
         t.is(error, failError)
         isError = true
         return {
@@ -225,7 +225,7 @@ test('spa should use errorProgram if loading fails', t => {
   })
 })
 
-test('spa should no-op for load errors if there is no errorProgram', t => {
+test('spa should no-op for load errors if there is no getErrorProgram', t => {
   t.plan(2)
 
   const router = createTestRouter({ initialValue: '/foo' })


### PR DESCRIPTION
It looks much better to have `getRouteProgram` and `getErrorProgram`. I'm keeping `errorProgram` around because it's easy enough. When bigger changes come around I'll clean that out.